### PR TITLE
Attempt to load the zone after generating it

### DIFF
--- a/contrib/iscbrf/iscbrf.py
+++ b/contrib/iscbrf/iscbrf.py
@@ -133,6 +133,8 @@ class iscBonk(object):
             lstrip_blocks=True)
 
         r = j2.get_template(os.path.basename(self.zone_template)).render(zone=zone, serial=serial + 1)
+        # Ensure that the zone can be understood by dnspython
+        dns.zone.from_text(r, zone)
 
         if outfile and r:
             if os.path.exists(outfile):


### PR DESCRIPTION
This prevents broken zones from being generated successfully.